### PR TITLE
Annotate the plot with max values

### DIFF
--- a/plot_delay.py
+++ b/plot_delay.py
@@ -89,5 +89,32 @@ ax.set_yticks([])
 ax.set_xlabel('Time [seconds]')
 ax.set_ylabel('Amplitude')
 plt.grid()
+
+# Find the maximum values and their corresponding times for loudness and red_intensity
+max_loudness_index = loudness.argmax()
+max_loudness_time = time_audio[max_loudness_index]
+max_loudness_value = loudness[max_loudness_index]
+
+max_red_intensity_index = red_intensity.argmax()
+max_red_intensity_time = time_video[max_red_intensity_index]
+max_red_intensity_value = red_intensity[max_red_intensity_index]
+
+# Annotate max values for loudness
+ax.annotate(f'Max Loudness at {max_loudness_time:.2f} s', 
+            (max_loudness_time, max_loudness_value),
+            textcoords="offset points",
+            xytext=(0, 10),
+            ha='center',
+            arrowprops=dict(arrowstyle="->"))
+
+# Annotate max values for red_intensity
+ax.annotate(f'Max Red Intensity at {max_red_intensity_time:.2f} s', 
+            (max_red_intensity_time, max_red_intensity_value),
+            textcoords="offset points",
+            xytext=(0, 25),
+            ha='center',
+            arrowprops=dict(arrowstyle="->"))
+
+
 plt.show()
 


### PR DESCRIPTION
Annotates the plot with maximum values and their corresponding times for loudness and red_intensity, so you can see the max values on the printout.

Issue: Wasn't able to zoom in on the plot like you in your how-to, so I created these annotations. However, it would only show one maximum value per category, so incase the video has e.g. a higher red peak at the end, the video would need a cut (will provide any easy fix for that in the next pr)

![image](https://github.com/davidnewschool/sound-delay/assets/34104015/db42218a-d5d6-4d67-abf9-85c907c2f5d4)
