### PR TITLE
Auto fetch audio of the mp4 file

### DIFF
--- a/plot_delay.py
+++ b/plot_delay.py
@@ -143,5 +143,32 @@ ax.set_yticks([])
 ax.set_xlabel('Time [seconds]')
 ax.set_ylabel('Amplitude')
 plt.grid()
+
+# Find the maximum values and their corresponding times for loudness and red_intensity
+max_loudness_index = loudness.argmax()
+max_loudness_time = time_audio[max_loudness_index]
+max_loudness_value = loudness[max_loudness_index]
+
+max_red_intensity_index = red_intensity.argmax()
+max_red_intensity_time = time_video[max_red_intensity_index]
+max_red_intensity_value = red_intensity[max_red_intensity_index]
+
+# Annotate max values for loudness
+ax.annotate(f'Max Loudness at {max_loudness_time:.2f} s', 
+            (max_loudness_time, max_loudness_value),
+            textcoords="offset points",
+            xytext=(0, 10),
+            ha='center',
+            arrowprops=dict(arrowstyle="->"))
+
+# Annotate max values for red_intensity
+ax.annotate(f'Max Red Intensity at {max_red_intensity_time:.2f} s', 
+            (max_red_intensity_time, max_red_intensity_value),
+            textcoords="offset points",
+            xytext=(0, 25),
+            ha='center',
+            arrowprops=dict(arrowstyle="->"))
+
+
 plt.show()
 

--- a/plot_delay.py
+++ b/plot_delay.py
@@ -36,8 +36,31 @@ def extract_audio_from_video(video_path):
 
 
 # Get input file paths
-audio_path = input('Enter path of audio file: ')
-video_path = input('Enter path of video file: ')
+while True:
+    video_path = input('Enter path of video file: ')
+
+    try:
+        with open(video_path, 'rb') as f:  # 'rb' mode is for reading binary files
+            print("Video found!")
+            break  # Exit the loop once a valid video path is provided
+    except FileNotFoundError:
+        print("Video not found. Please check the path and try again.")
+
+
+# If audio extraction fails, ask for audio path
+audio_path = extract_audio_from_video(video_path)
+if not audio_path:
+    while True:
+        audio_path = input('Enter path of audio file: ')
+
+        try:
+            with open(audio_path, 'rb') as f:  # 'rb' mode is for reading binary files
+                print("Audio found!")
+                break  # Exit the loop once a valid audio path is provided
+        except FileNotFoundError:
+            print("Audio not found. Please check the path and try again.")
+    
+
 
 #
 # Process Audio

--- a/plot_delay.py
+++ b/plot_delay.py
@@ -3,6 +3,37 @@ import matplotlib.pyplot as plt
 from mosqito.utils import load
 from mosqito.sq_metrics import loudness_zwtv
 import cv2
+try:
+    from moviepy.editor import VideoFileClip
+except RuntimeError:
+    print("Failed to initialize VideoFileClip. Ensure ffmpeg is installed.")
+except ImportError:
+    print("Failed to import VideoFileClip.")
+
+
+
+def extract_audio_from_video(video_path):
+    """Extract audio from the video."""
+    try:
+        # Check if VideoFileClip was imported
+        if 'VideoFileClip' not in globals():
+            raise RuntimeError("VideoFileClip is not imported. Ensure ffmpeg is installed and moviepy is imported successfully. You can still continue with providing your own soundfile as .wav")
+        
+        # Replace .mp4 with .wav (super simple)
+        audio_path = video_path[:-3] + 'wav'
+
+        video = VideoFileClip(video_path)
+        audio = video.audio
+        audio.write_audiofile(audio_path, codec='pcm_s16le')
+        audio.close()
+        
+        print("Audio extracted successfully!")
+        return audio_path
+    except Exception as e:
+        print(f"Error encountered during audio extraction: {e}")
+        return None
+
+
 
 # Get input file paths
 audio_path = input('Enter path of audio file: ')

--- a/plot_delay.py
+++ b/plot_delay.py
@@ -169,9 +169,9 @@ ax.annotate(f'Max Red Intensity at {max_red_intensity_time:.2f} s',
             ha='center',
             arrowprops=dict(arrowstyle="->"))
 
-
-plt.show()
-
 # Save the plot to the same path/name as the input video
 output_image_path = video_path[:-3] + 'png'
 plt.savefig(output_image_path)
+
+# show the plot
+plt.show()

--- a/plot_delay.py
+++ b/plot_delay.py
@@ -144,30 +144,6 @@ ax.set_xlabel('Time [seconds]')
 ax.set_ylabel('Amplitude')
 plt.grid()
 
-# Find the maximum values and their corresponding times for loudness and red_intensity
-max_loudness_index = loudness.argmax()
-max_loudness_time = time_audio[max_loudness_index]
-max_loudness_value = loudness[max_loudness_index]
-
-max_red_intensity_index = red_intensity.argmax()
-max_red_intensity_time = time_video[max_red_intensity_index]
-max_red_intensity_value = red_intensity[max_red_intensity_index]
-
-# Annotate max values for loudness
-ax.annotate(f'Max Loudness at {max_loudness_time:.2f} s', 
-            (max_loudness_time, max_loudness_value),
-            textcoords="offset points",
-            xytext=(0, 10),
-            ha='center',
-            arrowprops=dict(arrowstyle="->"))
-
-# Annotate max values for red_intensity
-ax.annotate(f'Max Red Intensity at {max_red_intensity_time:.2f} s', 
-            (max_red_intensity_time, max_red_intensity_value),
-            textcoords="offset points",
-            xytext=(0, 25),
-            ha='center',
-            arrowprops=dict(arrowstyle="->"))
 
 # Save the plot to the same path/name as the input video
 output_image_path = video_path[:-3] + 'png'

--- a/plot_delay.py
+++ b/plot_delay.py
@@ -172,3 +172,6 @@ ax.annotate(f'Max Red Intensity at {max_red_intensity_time:.2f} s',
 
 plt.show()
 
+# Save the plot to the same path/name as the input video
+output_image_path = video_path[:-3] + 'png'
+plt.savefig(output_image_path)


### PR DESCRIPTION
Will extract the audio source of the mp4 file, but also has some error handling.

Will only import moviepy.editor, if there is no error (if ffmpeg isn't installed, it can't import)
Will still be able to ask for another wav file, if no audio was extracted
Error Handling (re-asking) for user input for video & audio path
will save the plot with the same filename as the video in the same folder (for logging)